### PR TITLE
Fix wrapper function export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   push:
   schedule:
     # Daily 5am australian/brisbane time (7pm UTC)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: Release-Please (Build; Publish)
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./ast";
 export * from "./lexer";
 export * from "./parser";
 export * from "./token";
+export * from "./wrapper"


### PR DESCRIPTION
The index.ts file has been updated to export the wrapper functions. Also workflow_dispatch has been added to the workflows because a GitHub security limitation prevents PR created by a bot from triggering workflows, but the PRs have mandatory checks. See https://github.com/googleapis/release-please/issues/766 for more details on this limitation.